### PR TITLE
peer deps: bump prop-types version to "<=15.6.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "tape": "^4.7.0"
   },
   "peerDependencies": {
-    "prop-types": "<=15.6.0"
+    "prop-types": "<=15.6.1"
   }
 }


### PR DESCRIPTION
The new version of prop-types was released, and according to [their changelog](https://github.com/facebook/prop-types/blob/master/CHANGELOG.md#1561) there is only one minor change, so, there is no impact