### PR TITLE
Use var instead of const for better browser support

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@
  */
 function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
   if (process.env.NODE_ENV !== 'production') {
-    const ReactPropTypesSecret = require('prop-types/lib/ReactPropTypesSecret');
+    var ReactPropTypesSecret = require('prop-types/lib/ReactPropTypesSecret');
     var name = componentName || 'React class';
     for (var typeSpecName in typeSpecs) {
       if (typeSpecs.hasOwnProperty(typeSpecName)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-prop-types",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Check PropTypes, returning errors instead of logging them",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
-const test = require('tape');
-const PropTypes = require('prop-types');
-const checkPropTypes = require('.');
+var test = require('tape');
+var PropTypes = require('prop-types');
+var checkPropTypes = require('.');
 
 test('Good props check falsy', function(assert) {
   assert.plan(2);


### PR DESCRIPTION
This package does not compile via babel or anything, and it is otherwise not using ES6 features. By changing instances of const to var, this opens up to wider browser support.

In my particular case, this fixes an issue where a build chain uses uglify-js to condense the project. Uglify chokes on ES6 syntax (const in this case) that is present anywhere in the app or dependencies. I confirmed that this change relieves that issue.