### PR TITLE
[dist] Update peer dependency semver to work with newer prop-types versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-prop-types",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Check PropTypes, returning errors instead of logging them",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "prop-types": "^15.5.10",
+    "prop-types": "^15.6.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.7.0"
   },
   "peerDependencies": {
-    "prop-types": "<=15.6.0"
+    "prop-types": "^15.6.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # checkPropTypes
 
 [![Build Status](https://travis-ci.org/ratehub/check-prop-types.svg?branch=master)](https://travis-ci.org/ratehub/check-prop-types)
+[![View on npm](https://img.shields.io/npm/v/check-prop-types.svg)](https://www.npmjs.com/package/check-prop-types)
 
 Manually check [PropTypes](https://github.com/facebook/prop-types)-compatible proptypes, returning any errors instead of logging them to `console.error`.
 


### PR DESCRIPTION
Tests seem to work just fine with latest (15.7.2), so I'm proposing updating the `peerDependency` for `prop-types` to match the `devDependency` with a `^` semver.